### PR TITLE
add space regex in preparation for cldr@35

### DIFF
--- a/src/make-plural.js
+++ b/src/make-plural.js
@@ -24,6 +24,7 @@ class Parser {
       return 'n == 1 && v0'
     }
     return cond
+      .replace(/([^=\s])([!=%]+)([^=\s])/g, '$1 $2 $3')
       .replace(/([tv]) (!?)= 0/g, (m, sym, noteq) => {
         const sn = sym + '0'
         this[sn] = 1


### PR DESCRIPTION
@eemeli I'm looking for some pointer to finish this PR. This still doesn't work now, primarily bc there's potential overlapping ruleset between `other` & others. e.g for `kw`:
```
"kw": {
        "pluralRule-count-zero": "n = 0 @integer 0 @decimal 0.0, 0.00, 0.000, 0.0000",
        "pluralRule-count-one": "n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000",
        "pluralRule-count-two": "n % 100 = 2,22,42,62,82 or n%1000 = 0 and n%100000=1000..20000,40000,60000,80000 or n!=0 and n%1000000=100000@integer 2, 22, 42, 62, 82, 102, 122, 142, 1002, … @decimal 2.0, 22.0, 42.0, 62.0, 82.0, 102.0, 122.0, 142.0, 1002.0, …",
        "pluralRule-count-few": "n % 100 = 3,23,43,63,83 @integer 3, 23, 43, 63, 83, 103, 123, 143, 1003, … @decimal 3.0, 23.0, 43.0, 63.0, 83.0, 103.0, 123.0, 143.0, 1003.0, …",
        "pluralRule-count-many": "n != 1 and n % 100 = 1,21,41,61,81 @integer 21, 41, 61, 81, 101, 121, 141, 161, 1001, … @decimal 21.0, 41.0, 61.0, 81.0, 101.0, 121.0, 141.0, 161.0, 1001.0, …",
        "pluralRule-count-other": " @integer 4~19, 100, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
      },
```
As you can see, for value `1000.0` it matches both `other` & `two` (well technically `other` more). It doesn't look like currently `other` is being parsed at all, and even if it does the hierarchy would have to be changed to account for this.

Related:
https://unicode.org/cldr/trac/ticket/11078
https://unicode.org/cldr/trac/ticket/11876

Thoughts?