### PR TITLE
Clarify license for generated plurals package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2019 by Eemeli Aro <eemeli@gmail.com>
+Copyright © Eemeli Aro <eemeli@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/plurals/LICENSE
+++ b/packages/plurals/LICENSE
@@ -1,0 +1,32 @@
+Copyright © Eemeli Aro <eemeli@gmail.com>
+Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.

--- a/packages/plurals/package.json
+++ b/packages/plurals/package.json
@@ -10,7 +10,7 @@
     "pluralization"
   ],
   "author": "Eemeli Aro <eemeli@gmail.com>",
-  "license": "ISC",
+  "license": "Unicode-DFS-2016",
   "homepage": "https://github.com/eemeli/make-plural#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The canonical `make-plural` package is now licensed with the [OSI-approved](https://opensource.org/node/1077) Unicode Data Files and Software License, as it is based on the data provided in the `cldr-core` package, which is thus licensed. The `make-plural-compiler` and `make-plural-compiler` packages are my original work, and continue to be ISC-licensed.

The actual text of said license that's included is taken from [here](https://github.com/unicode-cldr/cldr-json/blob/master/LICENSE), which was recently updated following [this issue](https://unicode-org.atlassian.net/browse/CLDR-14143) in the CLDR bug tracker.

All prior releases of `make-plural` should probably be considered to be bound by this same license, given that they too are based on data provided by Unicode. I'm not really sure if something ought to be done about them, as they did not include this license text. @srl295, would you know if I should do something more?