### PR TITLE
Add Māori plural categories

### DIFF
--- a/packages/plurals/pluralCategories.d.ts
+++ b/packages/plurals/pluralCategories.d.ts
@@ -111,6 +111,7 @@ export const lv: {cardinal:["zero","one","other"],ordinal:["other"]};
 export const mas: {cardinal:["one","other"],ordinal:["other"]};
 export const mg: {cardinal:["one","other"],ordinal:["other"]};
 export const mgo: {cardinal:["one","other"],ordinal:["other"]};
+export const mi: {cardinal:["one","two","other"],ordinal:["zero","other"]};
 export const mk: {cardinal:["one","other"],ordinal:["one","two","many","other"]};
 export const ml: {cardinal:["one","other"],ordinal:["other"]};
 export const mn: {cardinal:["one","other"],ordinal:["other"]};


### PR DESCRIPTION
I'm not actually sure if this is exactly correct for Māori but I'm hoping you might have more resources on this than me.

My understanding is that cardinal numbers can refer to 1, 2, or 3+ (and 0?) (e.g. "koe", "kōrua", "koutou"), and ordinal numbers are 0-9, and 10+ (e.g. "tuatahi", "tuaiwa", "te tekau").

If everything in here is from the CLDR, do you have a recommendation on how to support locales not added there yet?